### PR TITLE
Renamed arguments named this with self to avoid g++ compile problems

### DIFF
--- a/inc/dtl_av.h
+++ b/inc/dtl_av.h
@@ -21,25 +21,25 @@ typedef struct dtl_av_tag{
 //Constructor/Destructor
 dtl_av_t*	dtl_av_new();
 dtl_av_t*	dtl_av_make(dtl_dv_t** ppValue, int32_t s32Len);
-void		dtl_av_delete(dtl_av_t *this);
-void		dtl_av_create(dtl_av_t *this);
-void		dtl_av_destroy(dtl_av_t *this);
+void		dtl_av_delete(dtl_av_t *self);
+void		dtl_av_create(dtl_av_t *self);
+void		dtl_av_destroy(dtl_av_t *self);
 
 //Accessors
-dtl_dv_t**	dtl_av_set(dtl_av_t *this, int32_t s32Index, dtl_dv_t *pValue);
-dtl_dv_t**	dtl_av_get(dtl_av_t *this, int32_t s32Index);
-void		dtl_av_push(dtl_av_t *this, dtl_dv_t *pValue);
-dtl_dv_t*	dtl_av_pop(dtl_av_t *this);
-dtl_dv_t*	dtl_av_shift(dtl_av_t *this);
-void		dtl_av_unshift(dtl_av_t *this, dtl_dv_t *pValue);
+dtl_dv_t**	dtl_av_set(dtl_av_t *self, int32_t s32Index, dtl_dv_t *pValue);
+dtl_dv_t**	dtl_av_get(dtl_av_t *self, int32_t s32Index);
+void		dtl_av_push(dtl_av_t *self, dtl_dv_t *pValue);
+dtl_dv_t*	dtl_av_pop(dtl_av_t *self);
+dtl_dv_t*	dtl_av_shift(dtl_av_t *self);
+void		dtl_av_unshift(dtl_av_t *self, dtl_dv_t *pValue);
 
 
 //Utility functions
-void	dtl_av_extend(dtl_av_t *this, int32_t s32Len);
-void	dtl_av_fill(dtl_av_t *this, int32_t s32Len);
-void	dtl_av_clear(dtl_av_t *this);
-int32_t dtl_av_length(dtl_av_t *this);
-bool	dtl_av_exists(dtl_av_t *this, int32_t s32Index);
+void	dtl_av_extend(dtl_av_t *self, int32_t s32Len);
+void	dtl_av_fill(dtl_av_t *self, int32_t s32Len);
+void	dtl_av_clear(dtl_av_t *self);
+int32_t dtl_av_length(dtl_av_t *self);
+bool	dtl_av_exists(dtl_av_t *self, int32_t s32Index);
 
 /*
 void dt_av_pushn(context_t *pContext, array_t *pArray, scalar_t **pScalars, uint32_t u32n);			//Pushes u32n SVs to the end of the array
@@ -47,6 +47,5 @@ int32_t dtl_av_popn(context_t *pContext, array_t *pArray, scalar_t **pScalars, u
 int32_t dtl_av_shiftn(context_t *pContext, array_t *pArray, scalar_t **pScalars, uint32_t u32n);		//Shifts (up to) u32n SVs from the start of the array
 void dtl_av_unshiftn(context_t *pContext, array_t *pArray, scalar_t **pScalars, uint32_t u32n);		//Unshifts u32n SVs to the start of the array
 */
-
 
 #endif //DTL_AV_H__

--- a/inc/dtl_dv.h
+++ b/inc/dtl_dv.h
@@ -47,5 +47,4 @@ void dtl_dv_ref_dec_void(void* ptr);
 #define dtl_ref_inc(dv) dtl_dv_ref_inc((dtl_dv_t*)dv)
 #define dtl_ref_dec(dv) dtl_dv_ref_dec((dtl_dv_t*)dv)
 
-
 #endif //DTL_DV_H__

--- a/inc/dtl_hv.h
+++ b/inc/dtl_hv.h
@@ -20,16 +20,16 @@ typedef struct dtl_hv_tag{
 /***************** Public Function Declarations *******************/
 //Constructor/Destructor
 dtl_hv_t*	dtl_hv_new(void);
-void		dtl_hv_delete(dtl_hv_t *this);
-void 	dtl_hv_create(dtl_hv_t *this);
-void 	dtl_hv_destroy(dtl_hv_t *this);
+void		dtl_hv_delete(dtl_hv_t *self);
+void 	dtl_hv_create(dtl_hv_t *self);
+void 	dtl_hv_destroy(dtl_hv_t *self);
 
 
 //Accessors
-void	dtl_hv_set(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen, dtl_dv_t *pValue);
-dtl_dv_t*	dtl_hv_get(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen);
-dtl_dv_t*	dtl_hv_remove(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen);
-void	dtl_hv_iter_init(dtl_hv_t *this);
+void	dtl_hv_set(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen, dtl_dv_t *pValue);
+dtl_dv_t*	dtl_hv_get(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen);
+dtl_dv_t*	dtl_hv_remove(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen);
+void	dtl_hv_iter_init(dtl_hv_t *self);
 
 /**
  * \param[in] this hash
@@ -37,15 +37,14 @@ void	dtl_hv_iter_init(dtl_hv_t *this);
  * \param[out] pKeyLen pointer to integer containing length of key string
  * \return pointer to scalar value
  */
-dtl_dv_t*	dtl_hv_iter_next(dtl_hv_t *this,const char **ppKey,uint32_t *pKeyLen);
+dtl_dv_t*	dtl_hv_iter_next(dtl_hv_t *self,const char **ppKey,uint32_t *pKeyLen);
 
 
 
 //Utility functions
-uint32_t 	dtl_hv_size(dtl_hv_t *this);
-bool		dtl_hv_exists(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen);
-uint32_t	dtl_hv_keys(dtl_hv_t *this,dtl_av_t *pArray);
-
+uint32_t 	dtl_hv_size(dtl_hv_t *self);
+bool		dtl_hv_exists(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen);
+uint32_t	dtl_hv_keys(dtl_hv_t *self,dtl_av_t *pArray);
 
 
 #endif //DTL_HV__

--- a/inc/dtl_sv.h
+++ b/inc/dtl_sv.h
@@ -61,9 +61,9 @@ extern dtl_sv_t g_dtl_sv_undef;
 /***************** Public Function Declarations *******************/
 //Constructor/Destructor
 dtl_sv_t* dtl_sv_new(void);
-void dtl_sv_delete(dtl_sv_t* this);
-void dtl_sv_create(dtl_sv_t* this);
-void dtl_sv_destroy(dtl_sv_t* this);
+void dtl_sv_delete(dtl_sv_t* self);
+void dtl_sv_create(dtl_sv_t* self);
+void dtl_sv_destroy(dtl_sv_t* self);
 dtl_sv_t *dtl_sv_make_i32(int32_t i32);
 dtl_sv_t *dtl_sv_make_u32(uint32_t u32);
 dtl_sv_t *dtl_sv_make_i64(int64_t i64);
@@ -75,38 +75,37 @@ dtl_sv_t *dtl_sv_make_ptr(void *ptr,void (*pDestructor)(void*));
 dtl_sv_t *dtl_sv_make_cstr(const char* str);
 dtl_sv_t *dtl_sv_make_dv(dtl_dv_t *dv);
 
-dtl_sv_type_id dtl_sv_type(dtl_sv_t* this);
+dtl_sv_type_id dtl_sv_type(dtl_sv_t* self);
 
 //Setters
-void dtl_sv_set_i32(dtl_sv_t *this, int32_t i32);
-void dtl_sv_set_u32(dtl_sv_t *this, uint32_t u32);
-void dtl_sv_set_i64(dtl_sv_t *this, int64_t i64);
-void dtl_sv_set_u64(dtl_sv_t *this, uint64_t u64);
-void dtl_sv_set_flt(dtl_sv_t *this, float flt);
-void dtl_sv_set_dbl(dtl_sv_t *this, double dbl);
-void dtl_sv_set_bool(dtl_sv_t *this, bool bl);
-void dtl_sv_set_ptr(dtl_sv_t *this, void *p, void (*pDestructor)(void*));
-void dtl_sv_set_cstr(dtl_sv_t *this, const char* str);
+void dtl_sv_set_i32(dtl_sv_t *self, int32_t i32);
+void dtl_sv_set_u32(dtl_sv_t *self, uint32_t u32);
+void dtl_sv_set_i64(dtl_sv_t *self, int64_t i64);
+void dtl_sv_set_u64(dtl_sv_t *self, uint64_t u64);
+void dtl_sv_set_flt(dtl_sv_t *self, float flt);
+void dtl_sv_set_dbl(dtl_sv_t *self, double dbl);
+void dtl_sv_set_bool(dtl_sv_t *self, bool bl);
+void dtl_sv_set_ptr(dtl_sv_t *self, void *p, void (*pDestructor)(void*));
+void dtl_sv_set_cstr(dtl_sv_t *self, const char* str);
 void dtl_sv_set_bstr(dtl_sv_t *self, const char *pBegin, const char *pEnd);
-void dtl_sv_set_dv(dtl_sv_t *this, dtl_dv_t *dv);
+void dtl_sv_set_dv(dtl_sv_t *self, dtl_dv_t *dv);
 
 
 
 //Getters
-int32_t dtl_sv_get_i32(dtl_sv_t *this);
-uint32_t dtl_sv_get_u32(dtl_sv_t *this);
-int64_t dtl_sv_get_i64(dtl_sv_t *this);
-uint64_t dtl_sv_get_u64(dtl_sv_t *this);
-float dtl_sv_get_flt(dtl_sv_t *this);
-double dtl_sv_get_dbl(dtl_sv_t *this);
-bool dtl_sv_get_bool(dtl_sv_t *this);
-void* dtl_sv_get_ptr(dtl_sv_t *this);
-const char *dtl_sv_get_cstr(dtl_sv_t *this);
-dtl_dv_t *dtl_sv_get_dv(dtl_sv_t *this);
-void dtl_sv_to_string(dtl_sv_t *this,adt_str_t *str);
+int32_t dtl_sv_get_i32(dtl_sv_t *self);
+uint32_t dtl_sv_get_u32(dtl_sv_t *self);
+int64_t dtl_sv_get_i64(dtl_sv_t *self);
+uint64_t dtl_sv_get_u64(dtl_sv_t *self);
+float dtl_sv_get_flt(dtl_sv_t *self);
+double dtl_sv_get_dbl(dtl_sv_t *self);
+bool dtl_sv_get_bool(dtl_sv_t *self);
+void* dtl_sv_get_ptr(dtl_sv_t *self);
+const char *dtl_sv_get_cstr(dtl_sv_t *self);
+dtl_dv_t *dtl_sv_get_dv(dtl_sv_t *self);
+void dtl_sv_to_string(dtl_sv_t *self,adt_str_t *str);
 
 //Macros
 #define dtl_sv_undef() &g_dtl_sv_undef
-
 
 #endif //DTL_SV_H__

--- a/src/dtl_av.c
+++ b/src/dtl_av.c
@@ -22,127 +22,127 @@
 /****************** Public Function Definitions *******************/
 //Constructor/Destructor
 dtl_av_t* dtl_av_new(){
-	dtl_av_t *this;
-	if((this = (dtl_av_t*)malloc(sizeof(dtl_av_t)))==(dtl_av_t*)0){
+	dtl_av_t *self;
+	if((self = (dtl_av_t*)malloc(sizeof(dtl_av_t)))==(dtl_av_t*)0){
 		return (dtl_av_t*)0;
 	}
-	if((this->pAny = (adt_ary_t*)malloc(sizeof(adt_ary_t)))==(adt_ary_t*)0){
-		free(this);
+	if((self->pAny = (adt_ary_t*)malloc(sizeof(adt_ary_t)))==(adt_ary_t*)0){
+		free(self);
 		return (dtl_av_t*)0;
 	}
-	dtl_av_create(this);
-	return this;
+	dtl_av_create(self);
+	return self;
 }
 
 dtl_av_t* dtl_av_make(dtl_dv_t** ppValue, int32_t s32Len){
 	if(s32Len<0){
 		return (dtl_av_t*)0;
 	}
-	dtl_av_t *this = dtl_av_new();
-	if(this){
+	dtl_av_t *self = dtl_av_new();
+	if(self){
 		int32_t s32i;
-		dtl_av_extend(this,s32Len);
+		dtl_av_extend(self,s32Len);
 		for(s32i=0;s32i<s32Len;s32i++){
-			dtl_av_set(this,s32i,ppValue[s32i]);
+			dtl_av_set(self,s32i,ppValue[s32i]);
 		}
 	}
-	return this;
+	return self;
 }
 
-void		dtl_av_delete(dtl_av_t *this){
-	if(this){
-		dtl_av_destroy(this);
-		free(this->pAny);
-		free(this);
+void		dtl_av_delete(dtl_av_t *self){
+	if(self){
+		dtl_av_destroy(self);
+		free(self->pAny);
+		free(self);
 	}
 }
 
-void dtl_av_create(dtl_av_t *this){
-	if(this){
-		adt_ary_create(this->pAny,dtl_dv_ref_dec_void);
-		adt_ary_set_fill_elem(this->pAny,(void*) &g_dtl_sv_undef);
-		this->u32Flags = ((uint32_t)DTL_DV_ARRAY);
-		this->u32RefCnt = 1;
+void dtl_av_create(dtl_av_t *self){
+	if(self){
+		adt_ary_create(self->pAny,dtl_dv_ref_dec_void);
+		adt_ary_set_fill_elem(self->pAny,(void*) &g_dtl_sv_undef);
+		self->u32Flags = ((uint32_t)DTL_DV_ARRAY);
+		self->u32RefCnt = 1;
 	}
 }
-void dtl_av_destroy(dtl_av_t *this){
-	if(this){
-		adt_ary_destroy(this->pAny);
+void dtl_av_destroy(dtl_av_t *self){
+	if(self){
+		adt_ary_destroy(self->pAny);
 	}
 }
 
 
 //Accessors
-dtl_dv_t**	dtl_av_set(dtl_av_t *this, int32_t s32Index, dtl_dv_t *pValue){
-	if(this){
-		dtl_dv_t **tmp = (dtl_dv_t**)adt_ary_get(this->pAny,s32Index);
+dtl_dv_t**	dtl_av_set(dtl_av_t *self, int32_t s32Index, dtl_dv_t *pValue){
+	if(self){
+		dtl_dv_t **tmp = (dtl_dv_t**)adt_ary_get(self->pAny,s32Index);
 		if(tmp && *tmp != pValue){
 			dtl_dv_ref_dec(*tmp);
 		}
-		return (dtl_dv_t**) adt_ary_set(this->pAny,s32Index,pValue);
+		return (dtl_dv_t**) adt_ary_set(self->pAny,s32Index,pValue);
 	}
 	return (dtl_dv_t**) 0;
 }
 
-dtl_dv_t**	dtl_av_get(dtl_av_t *this, int32_t s32Index){
-	if(this){
-		return (dtl_dv_t**) adt_ary_get(this->pAny,s32Index);
+dtl_dv_t**	dtl_av_get(dtl_av_t *self, int32_t s32Index){
+	if(self){
+		return (dtl_dv_t**) adt_ary_get(self->pAny,s32Index);
 	}
 	return (dtl_dv_t**) 0;
 }
 
-void dtl_av_push(dtl_av_t *this, dtl_dv_t *pValue){
-	if(this){
-		adt_ary_push(this->pAny,pValue);
+void dtl_av_push(dtl_av_t *self, dtl_dv_t *pValue){
+	if(self){
+		adt_ary_push(self->pAny,pValue);
 	}
 }
-dtl_dv_t* dtl_av_pop(dtl_av_t *this){
-	if(this){
-		return (dtl_dv_t*) adt_ary_pop(this->pAny);
+dtl_dv_t* dtl_av_pop(dtl_av_t *self){
+	if(self){
+		return (dtl_dv_t*) adt_ary_pop(self->pAny);
 	}
 	return (dtl_dv_t*)0;
 }
 
-dtl_dv_t*	dtl_av_shift(dtl_av_t *this){
-	if(this){
-		return (dtl_dv_t*) adt_ary_shift(this->pAny);
+dtl_dv_t*	dtl_av_shift(dtl_av_t *self){
+	if(self){
+		return (dtl_dv_t*) adt_ary_shift(self->pAny);
 	}
 	return (dtl_dv_t*)0;
 }
-void dtl_av_unshift(dtl_av_t *this, dtl_dv_t *pValue){
-	if(this){
-		adt_ary_unshift(this->pAny,pValue);
+void dtl_av_unshift(dtl_av_t *self, dtl_dv_t *pValue){
+	if(self){
+		adt_ary_unshift(self->pAny,pValue);
 	}
 }
 
 
 //Utility functions
-void	dtl_av_extend(dtl_av_t *this, int32_t s32Len){
-	if(this){
-		adt_ary_extend(this->pAny,s32Len);
+void	dtl_av_extend(dtl_av_t *self, int32_t s32Len){
+	if(self){
+		adt_ary_extend(self->pAny,s32Len);
 	}
 }
-void	dtl_av_fill(dtl_av_t *this, int32_t s32Len){
-	if(this){
-		adt_ary_fill(this->pAny,s32Len);
-	}
-}
-
-void	dtl_av_clear(dtl_av_t *this){
-	if(this){
-		adt_ary_clear(this->pAny);
+void	dtl_av_fill(dtl_av_t *self, int32_t s32Len){
+	if(self){
+		adt_ary_fill(self->pAny,s32Len);
 	}
 }
 
-int32_t dtl_av_length(dtl_av_t *this){
-	if(this){
-		return adt_ary_length(this->pAny);
+void	dtl_av_clear(dtl_av_t *self){
+	if(self){
+		adt_ary_clear(self->pAny);
+	}
+}
+
+int32_t dtl_av_length(dtl_av_t *self){
+	if(self){
+		return adt_ary_length(self->pAny);
 	}
 	return -1;
 }
-bool dtl_av_exists(dtl_av_t *this, int32_t s32Index){
-	if(this){
-		return adt_ary_exists(this->pAny,s32Index);
+bool dtl_av_exists(dtl_av_t *self, int32_t s32Index){
+	if(self){
+		return adt_ary_exists(self->pAny,s32Index);
 	}
 	return false;
 }

--- a/src/dtl_dv.c
+++ b/src/dtl_dv.c
@@ -16,19 +16,19 @@
 
 
 /**************** Private Function Declarations *******************/
-void dtl_dv_create(dtl_dv_t *this);
+void dtl_dv_create(dtl_dv_t *self);
 
 /**************** Private Variable Declarations *******************/
 
 
 /****************** Public Function Definitions *******************/
 dtl_dv_t *dtl_dv_null(void){
-	dtl_dv_t *this;
-	if((this = (dtl_dv_t*)malloc(sizeof(dtl_dv_t)))==(dtl_dv_t*)0){
+	dtl_dv_t *self;
+	if((self = (dtl_dv_t*)malloc(sizeof(dtl_dv_t)))==(dtl_dv_t*)0){
 		return (dtl_dv_t*)0;
 	}
-	dtl_dv_create(this);
-	return this;
+	dtl_dv_create(self);
+	return self;
 }
 
 void dtl_dv_delete(dtl_dv_t* dv ){
@@ -78,11 +78,11 @@ void dtl_dv_ref_dec_void(void* ptr){
 }
 
 /***************** Private Function Definitions *******************/
-void dtl_dv_create(dtl_dv_t *this){
-	if(this){
-		this->pAny = (void*) 0;
-		this->u32RefCnt = 1;
-		this->u32Flags =  ((uint32_t)DTL_DV_NULL);
+void dtl_dv_create(dtl_dv_t *self){
+	if(self){
+		self->pAny = (void*) 0;
+		self->u32RefCnt = 1;
+		self->u32Flags =  ((uint32_t)DTL_DV_NULL);
 	}
 }
 

--- a/src/dtl_hv.c
+++ b/src/dtl_hv.c
@@ -23,55 +23,55 @@
 /****************** Public Function Definitions *******************/
 //Constructor/Destructor
 dtl_hv_t* dtl_hv_new(void){
-	dtl_hv_t *this;
-	if((this = (dtl_hv_t*)malloc(sizeof(dtl_hv_t)))==(dtl_hv_t*)0){
+	dtl_hv_t *self;
+	if((self = (dtl_hv_t*)malloc(sizeof(dtl_hv_t)))==(dtl_hv_t*)0){
 		return (dtl_hv_t*)0;
 	}
-	if((this->pAny = (adt_hash_t*)malloc(sizeof(adt_hash_t)))==(adt_hash_t*)0){
-		free(this);
+	if((self->pAny = (adt_hash_t*)malloc(sizeof(adt_hash_t)))==(adt_hash_t*)0){
+		free(self);
 		return (dtl_hv_t*)0;
 	}
-	dtl_hv_create(this);
-	return this;
+	dtl_hv_create(self);
+	return self;
 }
 
-void dtl_hv_delete(dtl_hv_t *this){
-	if(this){
-		dtl_hv_destroy(this);
-		free(this->pAny);
-		free(this);
+void dtl_hv_delete(dtl_hv_t *self){
+	if(self){
+		dtl_hv_destroy(self);
+		free(self->pAny);
+		free(self);
 	}
 }
 
-void dtl_hv_create(dtl_hv_t *this){
-	if(this){
-		adt_hash_create(this->pAny,dtl_dv_ref_dec_void);
-		this->u32Flags = ((uint32_t)DTL_DV_HASH);
-		this->u32RefCnt = 1;
+void dtl_hv_create(dtl_hv_t *self){
+	if(self){
+		adt_hash_create(self->pAny,dtl_dv_ref_dec_void);
+		self->u32Flags = ((uint32_t)DTL_DV_HASH);
+		self->u32RefCnt = 1;
 	}
 }
 
-void dtl_hv_destroy(dtl_hv_t *this){
-	if(this){
-		adt_hash_destroy(this->pAny);
+void dtl_hv_destroy(dtl_hv_t *self){
+	if(self){
+		adt_hash_destroy(self->pAny);
 	}
 }
 
 
 //Accessors
-void dtl_hv_set(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen, dtl_dv_t *pValue){
-	if(this){
-		dtl_dv_t *pOld = (dtl_dv_t*) adt_hash_get(this->pAny,pKey,u32KeyLen);
+void dtl_hv_set(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen, dtl_dv_t *pValue){
+	if(self){
+		dtl_dv_t *pOld = (dtl_dv_t*) adt_hash_get(self->pAny,pKey,u32KeyLen);
 		if(pOld && pOld != pValue){
 			dtl_dv_ref_dec(pOld);
 		}
-		adt_hash_set(this->pAny,pKey,u32KeyLen,pValue);
+		adt_hash_set(self->pAny,pKey,u32KeyLen,pValue);
 	}
 }
 
-dtl_dv_t* dtl_hv_get(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen){
-	if(this){
-	   void **result = adt_hash_get(this->pAny,pKey,u32KeyLen);
+dtl_dv_t* dtl_hv_get(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen){
+	if(self){
+	   void **result = adt_hash_get(self->pAny,pKey,u32KeyLen);
 	   if (result != 0)
 	   {
 	      return (dtl_dv_t*) *result;
@@ -80,28 +80,28 @@ dtl_dv_t* dtl_hv_get(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen){
 	return (dtl_dv_t*) 0;
 }
 
-dtl_dv_t* dtl_hv_remove(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen){
-	if(this){
-		return (dtl_dv_t*) adt_hash_remove(this->pAny,pKey,u32KeyLen);
+dtl_dv_t* dtl_hv_remove(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen){
+	if(self){
+		return (dtl_dv_t*) adt_hash_remove(self->pAny,pKey,u32KeyLen);
 	}
 	return (dtl_dv_t*) 0;
 }
 
-void dtl_hv_iter_init(dtl_hv_t *this){
-	if(this){
-		adt_hash_iter_init(this->pAny);
+void dtl_hv_iter_init(dtl_hv_t *self){
+	if(self){
+		adt_hash_iter_init(self->pAny);
 	}
 }
 
 /**
- * \param[in] this hash
+ * \param[in] self hash
  * \param[out] pKey pointer to key string
  * \param[out] pKeyLen pointer to integer containing length of key string
  * \return pointer to scalar value
  */
-dtl_dv_t* dtl_hv_iter_next(dtl_hv_t *this,const char **ppKey,uint32_t *pKeyLen){
-	if(this){
-		return (dtl_dv_t*) adt_hash_iter_next(this->pAny,ppKey,pKeyLen);
+dtl_dv_t* dtl_hv_iter_next(dtl_hv_t *self,const char **ppKey,uint32_t *pKeyLen){
+	if(self){
+		return (dtl_dv_t*) adt_hash_iter_next(self->pAny,ppKey,pKeyLen);
 	}
 	return (dtl_dv_t*) 0;
 }
@@ -109,23 +109,23 @@ dtl_dv_t* dtl_hv_iter_next(dtl_hv_t *this,const char **ppKey,uint32_t *pKeyLen){
 
 
 //Utility functions
-uint32_t dtl_hv_size(dtl_hv_t *this){
-	if(this){
-		return adt_hash_size(this->pAny);
+uint32_t dtl_hv_size(dtl_hv_t *self){
+	if(self){
+		return adt_hash_size(self->pAny);
 	}
 	return (uint32_t) 0;
 }
 
-bool dtl_hv_exists(dtl_hv_t *this, const char *pKey, uint32_t u32KeyLen){
-	if(this){
-		return adt_hash_exists(this->pAny,pKey,u32KeyLen);
+bool dtl_hv_exists(dtl_hv_t *self, const char *pKey, uint32_t u32KeyLen){
+	if(self){
+		return adt_hash_exists(self->pAny,pKey,u32KeyLen);
 	}
 	return false;
 }
 
-uint32_t dtl_hv_keys(dtl_hv_t *this,dtl_av_t *pArray){
-	if(this && pArray){
-		return adt_hash_keys(this->pAny,pArray->pAny);
+uint32_t dtl_hv_keys(dtl_hv_t *self,dtl_av_t *pArray){
+	if(self && pArray){
+		return adt_hash_keys(self->pAny,pArray->pAny);
 	}
 	return 0;
 }

--- a/src/dtl_sv.c
+++ b/src/dtl_sv.c
@@ -29,7 +29,7 @@ static dtl_svx_t g_dtl_svx_undef = {0};
 dtl_sv_t g_dtl_sv_undef = {&g_dtl_svx_undef,1,((uint32_t)DTL_DV_SCALAR)};
 
 /**************** Private Function Declarations *******************/
-static void dtl_sv_set_type(dtl_sv_t *this,dtl_sv_type_id type);
+static void dtl_sv_set_type(dtl_sv_t *self,dtl_sv_type_id type);
 static void dtl_sv_ztrim(char *str);
 
 /**************** Private Variable Declarations *******************/
@@ -38,29 +38,29 @@ static void dtl_sv_ztrim(char *str);
 /****************** Public Function Definitions *******************/
 //Constructor/Destructor
 dtl_sv_t* dtl_sv_new(void){
-	dtl_sv_t *this;
-	if((this = (dtl_sv_t*)malloc(sizeof(dtl_sv_t)))==(dtl_sv_t*)0){
+	dtl_sv_t *self;
+	if((self = (dtl_sv_t*)malloc(sizeof(dtl_sv_t)))==(dtl_sv_t*)0){
 		return (dtl_sv_t*)0;
 	}
-	dtl_sv_create(this);
-	return this;
+	dtl_sv_create(self);
+	return self;
 }
 
-void dtl_sv_delete(dtl_sv_t* this){
-	if(this){
-		dtl_sv_destroy(this);
-		free(this);
+void dtl_sv_delete(dtl_sv_t* self){
+	if(self){
+		dtl_sv_destroy(self);
+		free(self);
 	}
 }
 
-void dtl_sv_create(dtl_sv_t* this){
-	if(this){
-		this->pAny = (dtl_svx_t*) malloc(sizeof(dtl_svx_t));
-		if (this->pAny != 0)
+void dtl_sv_create(dtl_sv_t* self){
+	if(self){
+		self->pAny = (dtl_svx_t*) malloc(sizeof(dtl_svx_t));
+		if (self->pAny != 0)
 		{
-		   memset(this->pAny, 0, sizeof(dtl_svx_t));
-	      this->u32Flags = ((uint32_t)DTL_DV_SCALAR);
-	      this->u32RefCnt = 1;
+		   memset(self->pAny, 0, sizeof(dtl_svx_t));
+	      self->u32Flags = ((uint32_t)DTL_DV_SCALAR);
+	      self->u32RefCnt = 1;
 		}
 		else
 		{
@@ -69,203 +69,203 @@ void dtl_sv_create(dtl_sv_t* this){
 	}
 }
 
-void dtl_sv_destroy(dtl_sv_t* this){
-	if(this){
-		switch(dtl_sv_type(this)){
+void dtl_sv_destroy(dtl_sv_t* self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_CSTR:
-			if(this->pAny->cstr) free(this->pAny->cstr);
+			if(self->pAny->cstr) free(self->pAny->cstr);
 			break;
 		case DTL_SV_PTR:
 			break;
-			if(this->pAny->ptr.pDestructor){
-				this->pAny->ptr.pDestructor(this->pAny->ptr.p);
+			if(self->pAny->ptr.pDestructor){
+				self->pAny->ptr.pDestructor(self->pAny->ptr.p);
 			}
 			break;
 		case DTL_SV_DV:
-			if(this->pAny->dv){
-				dtl_dv_ref_dec(this->pAny->dv);
+			if(self->pAny->dv){
+				dtl_dv_ref_dec(self->pAny->dv);
 			}
 			break;
 		default:
 			break;
 		}
-		free(this->pAny);
-		this->pAny = 0;
+		free(self->pAny);
+		self->pAny = 0;
 	}
 }
 
 dtl_sv_t *dtl_sv_make_i32(int32_t i32){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_i32(this,i32);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_i32(self,i32);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_u32(uint32_t u32){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_u32(this,u32);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_u32(self,u32);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_i64(int64_t i64){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_i64(this,i64);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_i64(self,i64);
 	}
-	return this;
+	return self;
 }
 dtl_sv_t *dtl_sv_make_u64(uint64_t u64){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_u64(this,u64);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_u64(self,u64);
 	}
-	return this;
+	return self;
 }
 
 
 dtl_sv_t *dtl_sv_make_flt(float flt){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_flt(this,flt);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_flt(self,flt);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_dbl(double dbl){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_dbl(this,dbl);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_dbl(self,dbl);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_bool(bool bl){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_bool(this,bl);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_bool(self,bl);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_ptr(void *ptr,void (*pDestructor)(void*)){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_ptr(this,ptr,pDestructor);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_ptr(self,ptr,pDestructor);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_cstr(const char* str){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_cstr(this,str);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_cstr(self,str);
 	}
-	return this;
+	return self;
 }
 
 dtl_sv_t *dtl_sv_make_dv(dtl_dv_t *dv){
-	dtl_sv_t *this = dtl_sv_new();
-	if(this){
-		dtl_sv_set_dv(this,dv);
+	dtl_sv_t *self = dtl_sv_new();
+	if(self){
+		dtl_sv_set_dv(self,dv);
 	}
-	return this;
+	return self;
 }
 
 
-dtl_sv_type_id dtl_sv_type(dtl_sv_t* this){
-	if(this){
-		uint8_t u8Type = (uint8_t) ((this->u32Flags & DTL_SV_TYPE_MASK)>>DTL_SV_TYPE_SHIFT);
+dtl_sv_type_id dtl_sv_type(dtl_sv_t* self){
+	if(self){
+		uint8_t u8Type = (uint8_t) ((self->u32Flags & DTL_SV_TYPE_MASK)>>DTL_SV_TYPE_SHIFT);
 		return (dtl_sv_type_id) u8Type;
 	}
 	return DTL_SV_UNDEF;
 }
 
 //Setters
-void dtl_sv_set_i32(dtl_sv_t *this, int32_t i32){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_i32(dtl_sv_t *self, int32_t i32){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_I32);
-		this->pAny->i32 = i32;
+		dtl_sv_set_type(self,DTL_SV_I32);
+		self->pAny->i32 = i32;
 	}
 }
 
-void dtl_sv_set_u32(dtl_sv_t *this, uint32_t u32){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_u32(dtl_sv_t *self, uint32_t u32){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_U32);
-		this->pAny->u32 = u32;
+		dtl_sv_set_type(self,DTL_SV_U32);
+		self->pAny->u32 = u32;
 	}
 }
 
-void dtl_sv_set_i64(dtl_sv_t *this, int64_t i64){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_i64(dtl_sv_t *self, int64_t i64){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_I64);
-		this->pAny->i64 = i64;
+		dtl_sv_set_type(self,DTL_SV_I64);
+		self->pAny->i64 = i64;
 	}
 }
 
-void dtl_sv_set_u64(dtl_sv_t *this, uint64_t u64){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_u64(dtl_sv_t *self, uint64_t u64){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_U64);
-		this->pAny->u64 = u64;
+		dtl_sv_set_type(self,DTL_SV_U64);
+		self->pAny->u64 = u64;
 	}
 }
 
 
-void dtl_sv_set_flt(dtl_sv_t *this, float flt){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_flt(dtl_sv_t *self, float flt){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_FLT);
-		this->pAny->flt = flt;
+		dtl_sv_set_type(self,DTL_SV_FLT);
+		self->pAny->flt = flt;
 	}
 }
-void dtl_sv_set_dbl(dtl_sv_t *this, double dbl){
-	if(this){
-		dtl_sv_set_type(this,DTL_SV_DBL);
-		this->pAny->dbl = dbl;
-	}
-}
-
-void dtl_sv_set_bool(dtl_sv_t *this, bool bl){
-	if(this){
-		dtl_sv_set_type(this,DTL_SV_BOOL);
-		this->pAny->bl = bl;
+void dtl_sv_set_dbl(dtl_sv_t *self, double dbl){
+	if(self){
+		dtl_sv_set_type(self,DTL_SV_DBL);
+		self->pAny->dbl = dbl;
 	}
 }
 
-void dtl_sv_set_ptr(dtl_sv_t *this, void *p, void (*pDestructor)(void*)){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_bool(dtl_sv_t *self, bool bl){
+	if(self){
+		dtl_sv_set_type(self,DTL_SV_BOOL);
+		self->pAny->bl = bl;
+	}
+}
+
+void dtl_sv_set_ptr(dtl_sv_t *self, void *p, void (*pDestructor)(void*)){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_PTR);
-		this->pAny->ptr.p = p;
-		this->pAny->ptr.pDestructor = pDestructor;
+		dtl_sv_set_type(self,DTL_SV_PTR);
+		self->pAny->ptr.p = p;
+		self->pAny->ptr.pDestructor = pDestructor;
 	}
 }
 
-void dtl_sv_set_cstr(dtl_sv_t *this, const char* str){
-	if(this){
-		dtl_sv_set_type(this,DTL_SV_CSTR);
-		if (this->pAny->cstr != 0){
-		   free(this->pAny->cstr);
+void dtl_sv_set_cstr(dtl_sv_t *self, const char* str){
+	if(self){
+		dtl_sv_set_type(self,DTL_SV_CSTR);
+		if (self->pAny->cstr != 0){
+		   free(self->pAny->cstr);
 		}
-		this->pAny->cstr = STRDUP(str);
+		self->pAny->cstr = STRDUP(str);
 	}
 }
 
@@ -282,38 +282,38 @@ void dtl_sv_set_bstr(dtl_sv_t *self, const char *pBegin, const char *pEnd){
    }
 }
 
-void dtl_sv_set_dv(dtl_sv_t *this, dtl_dv_t *dv){
-	if(this){
-		if(dtl_sv_type(this)==DTL_SV_DV){
-			dtl_dv_ref_dec(this->pAny->dv);
+void dtl_sv_set_dv(dtl_sv_t *self, dtl_dv_t *dv){
+	if(self){
+		if(dtl_sv_type(self)==DTL_SV_DV){
+			dtl_dv_ref_dec(self->pAny->dv);
 		}
-		dtl_sv_set_type(this,DTL_SV_DV);
-		this->pAny->dv = dv;
+		dtl_sv_set_type(self,DTL_SV_DV);
+		self->pAny->dv = dv;
 		dtl_dv_ref_inc(dv);
 	}
 }
 
 
 //Getters
-int32_t dtl_sv_get_i32(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+int32_t dtl_sv_get_i32(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return this->pAny->i32;
+			return self->pAny->i32;
 		case DTL_SV_U32:
-			return (int32_t) this->pAny->u32;
+			return (int32_t) self->pAny->u32;
 		case DTL_SV_I64:
-			return (int32_t) this->pAny->i64;
+			return (int32_t) self->pAny->i64;
 		case DTL_SV_U64:
-			return (int32_t) this->pAny->u64;
+			return (int32_t) self->pAny->u64;
 		case DTL_SV_FLT:
-			return (int32_t) this->pAny->flt;
+			return (int32_t) self->pAny->flt;
 		case DTL_SV_DBL:
-			return (int32_t) this->pAny->dbl;
+			return (int32_t) self->pAny->dbl;
 		case DTL_SV_BOOL:
-			return (int32_t) this->pAny->bl;
+			return (int32_t) self->pAny->bl;
 		case DTL_SV_CSTR:
 			break;
 		case DTL_SV_PTR:
@@ -324,55 +324,25 @@ int32_t dtl_sv_get_i32(dtl_sv_t *this){
 	}
 	return 0;
 }
-uint32_t dtl_sv_get_u32(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+uint32_t dtl_sv_get_u32(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return (uint32_t) this->pAny->i32;
+			return (uint32_t) self->pAny->i32;
 		case DTL_SV_U32:
-			return this->pAny->u32;
+			return self->pAny->u32;
 		case DTL_SV_I64:
-			return (uint32_t) this->pAny->i64;
+			return (uint32_t) self->pAny->i64;
 		case DTL_SV_U64:
-			return (uint32_t) this->pAny->u64;
+			return (uint32_t) self->pAny->u64;
 		case DTL_SV_FLT:
-			return (uint32_t) this->pAny->flt;
+			return (uint32_t) self->pAny->flt;
 		case DTL_SV_DBL:
-			return (uint32_t) this->pAny->dbl;
+			return (uint32_t) self->pAny->dbl;
 		case DTL_SV_BOOL:
-			return (uint32_t) this->pAny->bl;
-		case DTL_SV_CSTR:
-			break;
-		case DTL_SV_PTR:
-			break;
-		case DTL_SV_DV:
-			break;
-		}
-	}
-	return 0;
-}
-
-int64_t dtl_sv_get_i64(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
-		case DTL_SV_UNDEF:
-			break;
-		case DTL_SV_I32:
-			return (int64_t) this->pAny->i32;
-		case DTL_SV_U32:
-			return (int64_t) this->pAny->u32;
-		case DTL_SV_I64:
-			return this->pAny->i64;
-		case DTL_SV_U64:
-			return (int64_t) this->pAny->u64;
-		case DTL_SV_FLT:
-			return (int64_t) this->pAny->flt;
-		case DTL_SV_DBL:
-			return (int64_t) this->pAny->dbl;
-		case DTL_SV_BOOL:
-			return (int64_t) this->pAny->bl;
+			return (uint32_t) self->pAny->bl;
 		case DTL_SV_CSTR:
 			break;
 		case DTL_SV_PTR:
@@ -384,25 +354,55 @@ int64_t dtl_sv_get_i64(dtl_sv_t *this){
 	return 0;
 }
 
-uint64_t dtl_sv_get_u64(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+int64_t dtl_sv_get_i64(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return (uint64_t) this->pAny->i32;
+			return (int64_t) self->pAny->i32;
 		case DTL_SV_U32:
-			return (uint64_t) this->pAny->u32;
+			return (int64_t) self->pAny->u32;
 		case DTL_SV_I64:
-			return (uint64_t) this->pAny->i64;
+			return self->pAny->i64;
 		case DTL_SV_U64:
-			return this->pAny->u64;
+			return (int64_t) self->pAny->u64;
 		case DTL_SV_FLT:
-			return (uint64_t) this->pAny->flt;
+			return (int64_t) self->pAny->flt;
 		case DTL_SV_DBL:
-			return (uint64_t) this->pAny->dbl;
+			return (int64_t) self->pAny->dbl;
 		case DTL_SV_BOOL:
-			return (uint64_t) this->pAny->bl;
+			return (int64_t) self->pAny->bl;
+		case DTL_SV_CSTR:
+			break;
+		case DTL_SV_PTR:
+			break;
+		case DTL_SV_DV:
+			break;
+		}
+	}
+	return 0;
+}
+
+uint64_t dtl_sv_get_u64(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
+		case DTL_SV_UNDEF:
+			break;
+		case DTL_SV_I32:
+			return (uint64_t) self->pAny->i32;
+		case DTL_SV_U32:
+			return (uint64_t) self->pAny->u32;
+		case DTL_SV_I64:
+			return (uint64_t) self->pAny->i64;
+		case DTL_SV_U64:
+			return self->pAny->u64;
+		case DTL_SV_FLT:
+			return (uint64_t) self->pAny->flt;
+		case DTL_SV_DBL:
+			return (uint64_t) self->pAny->dbl;
+		case DTL_SV_BOOL:
+			return (uint64_t) self->pAny->bl;
 		case DTL_SV_CSTR:
 			break;
 		case DTL_SV_PTR:
@@ -415,25 +415,25 @@ uint64_t dtl_sv_get_u64(dtl_sv_t *this){
 }
 
 
-float dtl_sv_get_flt(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+float dtl_sv_get_flt(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return (float) this->pAny->i32;
+			return (float) self->pAny->i32;
 		case DTL_SV_U32:
-			return (float) this->pAny->u32;
+			return (float) self->pAny->u32;
 		case DTL_SV_I64:
-			return (float) this->pAny->i64;
+			return (float) self->pAny->i64;
 		case DTL_SV_U64:
-			return (float) this->pAny->u64;
+			return (float) self->pAny->u64;
 		case DTL_SV_FLT:
-			return this->pAny->flt;
+			return self->pAny->flt;
 		case DTL_SV_DBL:
-			return (float) this->pAny->dbl;
+			return (float) self->pAny->dbl;
 		case DTL_SV_BOOL:
-			return (float) this->pAny->bl;
+			return (float) self->pAny->bl;
 		case DTL_SV_CSTR:
 			break;
 		case DTL_SV_PTR:
@@ -445,25 +445,25 @@ float dtl_sv_get_flt(dtl_sv_t *this){
 	return 0.0;
 }
 
-double dtl_sv_get_dbl(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+double dtl_sv_get_dbl(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return (double) this->pAny->i32;
+			return (double) self->pAny->i32;
 		case DTL_SV_U32:
-			return (double) this->pAny->u32;
+			return (double) self->pAny->u32;
 		case DTL_SV_FLT:
-			return (double) this->pAny->flt;
+			return (double) self->pAny->flt;
 		case DTL_SV_I64:
-			return (double) this->pAny->i64;
+			return (double) self->pAny->i64;
 		case DTL_SV_U64:
-			return (double) this->pAny->u64;
+			return (double) self->pAny->u64;
 		case DTL_SV_DBL:
-			return this->pAny->dbl;
+			return self->pAny->dbl;
 		case DTL_SV_BOOL:
-			return (double) this->pAny->bl;
+			return (double) self->pAny->bl;
 		case DTL_SV_CSTR:
 			break;
 		case DTL_SV_PTR:
@@ -475,27 +475,27 @@ double dtl_sv_get_dbl(dtl_sv_t *this){
 	return 0.0;
 }
 
-bool dtl_sv_get_bool(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+bool dtl_sv_get_bool(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return (bool) this->pAny->i32;
+			return (bool) self->pAny->i32;
 		case DTL_SV_U32:
-			return (bool) this->pAny->u32;
+			return (bool) self->pAny->u32;
 		case DTL_SV_I64:
-			return (bool) this->pAny->i64;
+			return (bool) self->pAny->i64;
 		case DTL_SV_U64:
-			return (bool) this->pAny->u64;
+			return (bool) self->pAny->u64;
 		case DTL_SV_FLT:
-			return (bool) this->pAny->flt;
+			return (bool) self->pAny->flt;
 		case DTL_SV_DBL:
-			return (bool) this->pAny->dbl;
+			return (bool) self->pAny->dbl;
 		case DTL_SV_BOOL:
-			return this->pAny->bl;
+			return self->pAny->bl;
 		case DTL_SV_CSTR:
-			if(strcmp(this->pAny->cstr,"true")==0){
+			if(strcmp(self->pAny->cstr,"true")==0){
 				return true;
 			}
 			break;
@@ -508,15 +508,15 @@ bool dtl_sv_get_bool(dtl_sv_t *this){
 	return false;
 }
 
-void* dtl_sv_get_ptr(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+void* dtl_sv_get_ptr(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
-			return (void*) ((long) this->pAny->i32);
+			return (void*) ((long) self->pAny->i32);
 		case DTL_SV_U32:
-			return (void*) ((long) this->pAny->u32);
+			return (void*) ((long) self->pAny->u32);
 		case DTL_SV_I64:
 			break;
 		case DTL_SV_U64:
@@ -528,22 +528,22 @@ void* dtl_sv_get_ptr(dtl_sv_t *this){
 		case DTL_SV_BOOL:
 			break;
 		case DTL_SV_CSTR:
-			return (void*) this->pAny->cstr;
+			return (void*) self->pAny->cstr;
 			break;
 		case DTL_SV_PTR:
-			return this->pAny->ptr.p;
+			return self->pAny->ptr.p;
 			break;
 		case DTL_SV_DV:
-			return (void*) this->pAny->dv;
+			return (void*) self->pAny->dv;
 			break;
 		}
 	}
 	return (void*)0;
 }
 
-const char* dtl_sv_get_cstr(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+const char* dtl_sv_get_cstr(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
@@ -559,9 +559,9 @@ const char* dtl_sv_get_cstr(dtl_sv_t *this){
 		case DTL_SV_DBL:
 			break;
 		case DTL_SV_BOOL:
-			return this->pAny->bl? "true" : "false";
+			return self->pAny->bl? "true" : "false";
 		case DTL_SV_CSTR:
-			return this->pAny->cstr;
+			return self->pAny->cstr;
 			break;
 		case DTL_SV_PTR:
 			break;
@@ -572,9 +572,9 @@ const char* dtl_sv_get_cstr(dtl_sv_t *this){
 	return (const char*)0;
 }
 
-dtl_dv_t *dtl_sv_get_dv(dtl_sv_t *this){
-	if(this){
-		switch(dtl_sv_type(this)){
+dtl_dv_t *dtl_sv_get_dv(dtl_sv_t *self){
+	if(self){
+		switch(dtl_sv_type(self)){
 		case DTL_SV_UNDEF:
 			break;
 		case DTL_SV_I32:
@@ -596,7 +596,7 @@ dtl_dv_t *dtl_sv_get_dv(dtl_sv_t *this){
 		case DTL_SV_PTR:
 			break;
 		case DTL_SV_DV:
-			return this->pAny->dv;
+			return self->pAny->dv;
 			break;
 		}
 	}
@@ -669,9 +669,9 @@ void dtl_sv_to_string(dtl_sv_t *sv,adt_str_t *str){
 
 
 /***************** Private Function Definitions *******************/
-void dtl_sv_set_type(dtl_sv_t *this,dtl_sv_type_id type){
-	this->u32Flags &= ~((uint32_t)DTL_SV_TYPE_MASK);
-	this->u32Flags |= (((uint32_t)type)<<DTL_SV_TYPE_SHIFT) & DTL_SV_TYPE_MASK;
+void dtl_sv_set_type(dtl_sv_t *self,dtl_sv_type_id type){
+	self->u32Flags &= ~((uint32_t)DTL_SV_TYPE_MASK);
+	self->u32Flags |= (((uint32_t)type)<<DTL_SV_TYPE_SHIFT) & DTL_SV_TYPE_MASK;
 }
 
 void dtl_sv_ztrim(char *str){


### PR DESCRIPTION
Renamed arguments named this to self due to that this is a protected keyword in g++. 